### PR TITLE
Columns on List page should have path / id first

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { ResourceSchema } from "./state/openapi";
 import SpecSpecifierPage from "./app/spec_specifier/page";
 import { createBrowserRouter, RouteObject, RouterProvider } from "react-router-dom";
 import Layout from "./app/explorer/page";
-import ResourceList from "./app/explorer/resource_list";
+import ResourceListPage from "./app/explorer/resource_list";
 import CreateForm from "./app/explorer/form";
 import InfoPage from "./app/explorer/info";
 import UpdateForm from "./app/explorer/update_form";
@@ -24,7 +24,7 @@ function createRoutes(resources: ResourceSchema[]): RouteObject[] {
       return [
         {
           path: resource.base_url(),
-          element: <ResourceList resource={resource} />
+          element: <ResourceListPage resource={resource} />
         },
         {
           path: `${resource.base_url()}/_create`,

--- a/src/app/explorer/page.tsx
+++ b/src/app/explorer/page.tsx
@@ -16,7 +16,9 @@ export default function Layout() {
           <Separator orientation="vertical" className="mr-2 h-4" />
           <AppBreadcrumb />
         </header>
-        <Outlet />
+        <div className="p-4">
+          <Outlet />
+        </div>
         <Toaster />
       </SidebarInset>
     </SidebarProvider>

--- a/src/components/resource_list.tsx
+++ b/src/components/resource_list.tsx
@@ -1,0 +1,97 @@
+import { DataTable } from "@/components/ui/data-table";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { MoreHorizontal } from "lucide-react";
+import { ResourceSchema } from "@/state/openapi";
+import { ResourceInstance } from "@/state/fetch";
+import { useNavigate } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+
+type ResourceListTableProps = {
+    resource: ResourceSchema;
+    resources: ResourceInstance[];
+    onRefresh: () => void;
+}
+
+export function ResourceListTable({ resource, resources, onRefresh }: ResourceListTableProps) {
+    const navigate = useNavigate();
+    
+    const dropDownMenuColumn = {
+        id: "actions",
+        accessorKey: "actions",
+        header: "Actions",
+        enableHiding: false,
+        cell: ({ row }: { row: { original: ResourceInstance } }) => {
+            const resource = row.original;
+
+            return (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                            <span className="sr-only">Open menu</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                            onClick={() => deleteResource(resource)}
+                        >
+                            <span className="text-red-600">Delete</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            onClick={() => navigate(resource['id'])}
+                        >
+                            <span>Info</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            onClick={() => navigate(`${resource['id']}/_update`)}
+                        >
+                            <span>Update</span>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            )
+        },
+    };
+
+    function createColumns(r: ResourceSchema | undefined) {
+        if(r) {
+            const properties = r.properties();
+            const columns = properties
+                .sort((a, b) => {
+                    // First sort by priority (path and id first)
+                    const priorityOrder = { path: 0, id: 1 };
+                    const aPriority = priorityOrder[a.name as keyof typeof priorityOrder] ?? 2;
+                    const bPriority = priorityOrder[b.name as keyof typeof priorityOrder] ?? 2;
+                    
+                    if (aPriority !== bPriority) {
+                        return aPriority - bPriority;
+                    }
+                    
+                    // Then sort alphabetically
+                    return a.name.localeCompare(b.name);
+                })
+                .map((prop) => {
+                    return {accessorKey: prop.name, header: prop.name}
+                });
+            columns.push(dropDownMenuColumn);
+            return columns;
+        } else {
+            return [];
+        }
+    }
+
+    function deleteResource(r: ResourceInstance) {
+        r.delete().then(() => {
+            toast({description: `Deleted ${r.path}`});
+            onRefresh();
+        });
+    }
+
+    return (
+        <DataTable 
+            columns={createColumns(resource)} 
+            data={resources.map((resource) => resource.properties)} 
+        />
+    );
+} 


### PR DESCRIPTION
Fixes #31 
(actually) Fixes #33

This does a couple things:
- Actually fixes the page padding
- Moves the resource table to a separate component file
- Changes that component so that it sorts path + id before other columns (all other columns are alphabetical after that)
