### PR TITLE
Fixing some things (I might've broken) + starting parent-child relationships

### DIFF
--- a/src/app/explorer/form.tsx
+++ b/src/app/explorer/form.tsx
@@ -23,7 +23,7 @@ export default function CreateForm(props: CreateFormProps) {
         // Value is the properly formed JSON body.
         // Just need to submit it and navigate back to the list page.
         props.resource.create(value, headers).then(() => {
-            toast({description: `Created ${value.id}`});
+            toast({description: `Created new resource`});
             navigate(-1);
         })
 

--- a/src/app/explorer/info.tsx
+++ b/src/app/explorer/info.tsx
@@ -32,7 +32,7 @@ export default function InfoPage(props: InfoPageProps) {
     return (
         <Card>
         <CardHeader>
-            <CardTitle>{state.properties?.id}</CardTitle>
+            <CardTitle>{state.properties?.path}</CardTitle>
         </CardHeader>
         <CardContent>
             {properties}


### PR DESCRIPTION
Fixes #37 

Gets somewhere towards fixing #30 

My last change might've broken some things. This fixes that! 

- Gets the info button working again
- Replaces some bad id instances with path. This was breaking some parts of the create flow
- The beginnings of substituting parent values into URLs for parent-child relationships

We have two containers of data for resources: a ResourceSchema (the schema) and ResourceInstances (a user-created instance of a Resource). Certain actions can be performed with a ResourceSchema (create, list, get) and others on a ResourceInstance (delete, update). I've added a set of parent ResourceInstances on a ResourceSchema. This is important for parent-child relationships, since those parent ResourceInstances will contain the necessary parent information to allow ResourceSchema actions to occur.

Next things we need to do:
- Figure out how/when to inject the ResourceInstance parents into ResourceSchema
- Fix the routing (which doesn't really work for parent-child resources as-is)
- I'm sure there will be more things from here...

